### PR TITLE
Rails 論文評価処理実装

### DIFF
--- a/rails/backend/app/api/v1/search.rb
+++ b/rails/backend/app/api/v1/search.rb
@@ -17,8 +17,8 @@ module V1
         parse_value = JSON.parse(return_value)
 
 
-        # 係数
-        coefficient = 5
+        # 論文評価係数を取得
+        coefficient = Paperevaluation.select(:factor).last[:factor]
         parse_value.each do |paper_info|
           # Pick数を検索
           paper = Paper.find_by(url: paper_info["url"])

--- a/rails/backend/app/models/paperevaluation.rb
+++ b/rails/backend/app/models/paperevaluation.rb
@@ -1,0 +1,2 @@
+class Paperevaluation < ApplicationRecord
+end

--- a/rails/backend/app/utils/TestWorkSpace.rb
+++ b/rails/backend/app/utils/TestWorkSpace.rb
@@ -38,10 +38,17 @@ class TestWorkSpace
     return parse_value.to_json
   end
 
-  def create
+  def create_citation_data
     Citation.create(count: 10)
   end
 
+  def create_paperevaluation_data
+    Paperevaluation.create(factor: 5)
+  end
+
+  def get
+    p Paperevaluation.select(:factor).last[:factor]
+  end
 end
 
 # やる事

--- a/rails/backend/db/migrate/20210901131113_create_paperevaluations.rb
+++ b/rails/backend/db/migrate/20210901131113_create_paperevaluations.rb
@@ -1,0 +1,9 @@
+class CreatePaperevaluations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :paperevaluations do |t|
+      t.integer :factor
+
+      t.timestamps
+    end
+  end
+end

--- a/rails/backend/db/schema.rb
+++ b/rails/backend/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_01_122239) do
+ActiveRecord::Schema.define(version: 2021_09_01_131113) do
 
   create_table "citations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.integer "count"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "paperevaluations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.integer "factor"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/rails/backend/test/fixtures/paperevaluations.yml
+++ b/rails/backend/test/fixtures/paperevaluations.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  factor: 1
+
+two:
+  factor: 1

--- a/rails/backend/test/models/paperevaluation_test.rb
+++ b/rails/backend/test/models/paperevaluation_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PaperevaluationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
<変更点>

・論文評価係数を保存するテーブルの定義と反映
・search.rbに論文評価係数を取り出す処理を実装