### PR TITLE
ホスト名をホワイトリストに追加

### DIFF
--- a/rails/backend/config/environments/development.rb
+++ b/rails/backend/config/environments/development.rb
@@ -49,4 +49,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # hostをホワイトリストに追加
+  config.hosts << "paperpicks.jp"
 end


### PR DESCRIPTION
<変更点>
・開発環境で、パブリックホスト名をホワイトリストに追加した